### PR TITLE
Simplify the gene mention extractor

### DIFF
--- a/code/gene_extract_candidates.py
+++ b/code/gene_extract_candidates.py
@@ -24,7 +24,7 @@ def read_phrase_to_genes():
     for line in f:
       phrase,ensembl_id,mapping_type = line.rstrip('\n').split('\t')
       phrase_to_genes[phrase].add((ensembl_id,mapping_type))
-      lower_phrase_to_genes[phrase].add((ensembl_id,mapping_type))
+      lower_phrase_to_genes[phrase.lower()].add((ensembl_id,mapping_type))
   
   return phrase_to_genes, lower_phrase_to_genes
 

--- a/code/gene_extract_candidates.py
+++ b/code/gene_extract_candidates.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import collections
 import extractor_util as util
+import random
 import re
 import os
 import sys
@@ -67,7 +68,11 @@ def get_mentions_for_row(row):
       for ensembl_id,mapping_type in exact_case_matches.union(lowercase_matches):
         mentions.append(util.create_mention(row, [i], [word], ensembl_id, mapping_type))
     elif word == word.upper() and word.isalnum() and not unicode(word).isnumeric() and len(word) > 2:
-      mentions.append(util.create_mention(row, [i], [word], 'ALL_UPPERCASE_NOT_GENE_SYMBOL', 'ALL_UPPERCASE_NOT_GENE_SYMBOL'))
+      if random.random() < 0.05:
+        mentions.append(util.create_mention(row, [i], [word], 'ALL_UPPERCASE_NOT_GENE_SYMBOL', 'ALL_UPPERCASE_NOT_GENE_SYMBOL'))
+    elif random.random() < 0.0001:
+        mentions.append(util.create_mention(row, [i], [word], 'RANDOM_WORD_NOT_GENE_SYMBOL', 'RANDOM_WORD_NOT_GENE_SYMBOL'))
+
   return mentions
 
 
@@ -79,7 +84,7 @@ def get_supervision(row, mention):
 
   # Negative Rule #1: words that are all uppercase but are not in the gene symbol
   # list are likely false mentions.
-  if mention.mention_type in ('ALL_UPPERCASE_NOT_GENE_SYMBOL'):
+  if mention.mention_type in ('ALL_UPPERCASE_NOT_GENE_SYMBOL', 'RANDOM_WORD_NOT_GENE_SYMBOL'):
     return False
 
   # Positive Rule #2: matches from papers that NCBI annotates as being about

--- a/code/gene_extract_candidates.py
+++ b/code/gene_extract_candidates.py
@@ -87,7 +87,7 @@ def get_supervision(row, mention):
   if mention.mention_type in ('ALL_UPPERCASE_NOT_GENE_SYMBOL', 'RANDOM_WORD_NOT_GENE_SYMBOL'):
     return False
 
-  # Positive Rule #2: matches from papers that NCBI annotates as being about
+  # Positive Rule #1: matches from papers that NCBI annotates as being about
   # the mentioned gene are likely true.
   pubmed_to_genes = CACHE['pubmed_to_genes']
   if '.'.join(row.doc_id.split('.')[1:]) == "html.txt.nlp.task":

--- a/code/gene_extract_features.py
+++ b/code/gene_extract_features.py
@@ -46,7 +46,7 @@ def get_features_for_row(row):
   sentence = create_sentence(row)
   span = ddlib.Span(begin_word_id=row.wordidxs[0], length=len(row.wordidxs))
   return [(row.doc_id, row.mention_id, feat)
-          for feat in ddlib.get_generic_features_mention(sentence, span)]
+          for feat in ddlib.get_generic_features_mention(sentence, span) if not (feat.startswith("LEMMA_SEQ") or feat.startswith("WORD_SEQ"))]
 
 
 def main():


### PR DESCRIPTION
Improve the gene mention extractor by simplication.  Instead of
special cases, have one entity identification rule and two simple
supervision rules: true positives come from PMID<->gene mappings
from NCBI, and true negatives come from uppercase words that
are not gene symbols.
